### PR TITLE
Update documentation to match `terraform.io` formatting

### DIFF
--- a/website/docs/r/ssh_key.html.markdown
+++ b/website/docs/r/ssh_key.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Manages SoftLayer SSH Keys.
 ---
 
-# softlayer\ssh_key
+# softlayer\_ssh\_key
 
 Provides SSK keys. This allows SSH keys to be created, updated and deleted.
 For additional details please refer to [API documentation](http://sldn.softlayer.com/reference/datatypes/SoftLayer_Security_Ssh_Key).

--- a/website/docs/r/virtual_guest.html.markdown
+++ b/website/docs/r/virtual_guest.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Manages SoftLayer Virtual Guests.
 ---
 
-# softlayer\virtual_guest
+# softlayer\_virtual\_guest
 
 Provides virtual guest resource. This allows virtual guests to be created, updated
 and deleted. For additional details please refer to [API documentation](http://sldn.softlayer.com/reference/services/SoftLayer_Virtual_Guest).
@@ -55,77 +55,27 @@ resource "softlayer_virtual_guest" "terraform-sample-BDTGroup" {
 
 The following arguments are supported:
 
-* `name` | *string*
-	* Hostname for the computing instance.
-	* **Required**
-* `domain` | *string*
-	* Domain for the computing instance.
-	* **Required**
-* `cpu` | *int*
-	* The number of CPU cores to allocate.
-	* **Required**
-* `ram` | *int*
-	* The amount of memory to allocate in megabytes.
-	* **Required**
-* `region` | *string*
-	* Specifies which datacenter the instance is to be provisioned in.
-	* **Required**
-* `hourly_billing` | *boolean*
-	* Specifies the billing type for the instance. When `true`, the computing instance will be billed on hourly usage, otherwise it will be billed on a monthly basis.
-	* **Required**
-* `local_disk` | *boolean*
-	* Specifies the disk type for the instance. When `true`, the disks for the computing instance will be provisioned on the host which it runs, otherwise SAN disks will be provisioned.
-	* **Required**
-* `dedicated_acct_host_only` | *boolean*
-	* Specifies whether or not the instance must only run on hosts with instances from the same account
-	* *Default*: nil
-	* *Optional*
-* `image` | *string*
-	* An identifier for the operating system to provision the computing instance with.
-	* **Conditionally required**	- Disallowed when `blockDeviceTemplateGroup.globalIdentifier` is provided, as the template will specify the operating system.
-* `block_device_template_group_gid` | *string*
-	* A global identifier for the template to be used to provision the computing instance.
-	* **Conditionally required**	- Disallowed when `operatingSystemReferenceCode` is provided, as the template will specify the operating system.
-* `public_network_speed` | *int*
-	* Specifies the connection speed for the instance's network components.
-	* *Default*: 10
-	* *Optional*
-* `private_network_only` | *boolean*
-	* Specifies whether or not the instance only has access to the private network. When true this flag specifies that a compute instance is to only have access to the private network.
-	* *Default*: False
-	* *Optional*
-* `frontend_vlan_id` | *int*
-	* Specifies the network VLAN which is to be used for the front end interface of the computing instance.
-	* *Default*: nil
-	* *Optional*
-* `backend_vlan_id` | *int*
-	* Specifies the network VLAN which is to be used for the back end interface of the computing instance.
-	* *Default*: nil
-	* *Optional*
-* `disks` | *array*
-	* Block device and disk image settings for the computing instance
-	* *Optional*
+* `name` - (Required, string) Hostname for the computing instance.
+* `domain` - (Required, string) Domain for the computing instance.
+* `cpu` - (Required, int) The number of CPU cores to allocate.
+* `ram` - (Required, int) The amount of memory to allocate in megabytes.
+* `region` - (Required, string) Specifies which datacenter the instance is to be provisioned in.
+* `hourly_billing` - (Required, boolean) Specifies the billing type for the instance. When `true`, the computing instance will be billed on hourly usage, otherwise it will be billed on a monthly basis.
+* `local_disk` - (Required, boolean) Specifies the disk type for the instance. When `true`, the disks for the computing instance will be provisioned on the host which it runs, otherwise SAN disks will be provisioned.
+* `dedicated_acct_host_only` - (Optional, boolean) Specifies whether or not the instance must only run on hosts with instances from the same account
+* `image` - (Conditionally required, string) An identifier for the operating system to provision the computing instance with. Disallowed when `blockDeviceTemplateGroup.globalIdentifier` is provided, as the template will specify the operating system.
+* `block_device_template_group_gid` - (Conditionally required, string) A global identifier for the template to be used to provision the computing instance. Disallowed when `operatingSystemReferenceCode` is provided, as the template will specify the operating system.
+* `public_network_speed` - (Optional, int, default 10) Specifies the connection speed for the instance's network components.
+* `private_network_only` - (Optional, boolean, default false) Specifies whether or not the instance only has access to the private network. When true this flag specifies that a compute instance is to only have access to the private network.
+* `frontend_vlan_id` - (Optional, int) Specifies the network VLAN which is to be used for the front end interface of the computing instance.
+* `backend_vlan_id` - (Optional, int) Specifies the network VLAN which is to be used for the back end interface of the computing instance.
+* `disks` - (Optional, array) Block device and disk image settings for the computing instance
 	* *Default*: The smallest available capacity for the primary disk will be used. If an image template is specified the disk capacity will be be provided by the template.
-* `user_data` | *string*
-	* Arbitrary data to be made available to the computing instance.
-	* *Default*: nil
-	* *Optional*
-* `ssh_keys` | *array*
-	* SSH keys to install on the computing instance upon provisioning.
-	* *Default*: nil
-	* *Optional*
-* `ipv4_address` | *string*
-	* Uses `editObject` call, template data [defined here](https://sldn.softlayer.com/reference/datatypes/SoftLayer_Virtual_Guest).
-	* *Default*: nil
-	* *Optional*
-* `ipv4_address_private` | *string*
-	* Uses `editObject` call, template data [defined here](https://sldn.softlayer.com/reference/datatypes/SoftLayer_Virtual_Guest).
-	* *Default*: nil
-	* *Optional*
-* `post_install_script_uri` | *string*
-	* As defined in the [SoftLayer_Virtual_Guest_SupplementalCreateObjectOptions](https://sldn.softlayer.com/reference/datatypes/SoftLayer_Virtual_Guest_SupplementalCreateObjectOptions).
-	* *Default*: nil
-	* *Optional*
+* `user_data` - (Optional, string) Arbitrary data to be made available to the computing instance.
+* `ssh_keys` - (Optional, array) SSH keys to install on the computing instance upon provisioning.
+* `ipv4_address` - (Optional, string) Uses `editObject` call, template data [defined here](https://sldn.softlayer.com/reference/datatypes/SoftLayer_Virtual_Guest).
+* `ipv4_address_private` - (Optional, string) Uses `editObject` call, template data [defined here](https://sldn.softlayer.com/reference/datatypes/SoftLayer_Virtual_Guest).
+* `post_install_script_uri` - (Optional, string) As defined in the [SoftLayer_Virtual_Guest_SupplementalCreateObjectOptions](https://sldn.softlayer.com/reference/datatypes/SoftLayer_Virtual_Guest_SupplementalCreateObjectOptions).
 
 ## Attributes Reference
 


### PR DESCRIPTION
Update the `virtual_guest` documentation file to match the formatting used for the rest of the resources on `terraform.io`.